### PR TITLE
some minor changes to improve the error messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,4 @@ rules-reviewed/CreateIDs.xsl
 rules-reviewed/CreateTests.xsl
 rules-reviewed/tags.txt
 tags.txt
-
+.vscode

--- a/src/test/java/org/jboss/windup/rules/tests/WindupRulesMultipleTests.java
+++ b/src/test/java/org/jboss/windup/rules/tests/WindupRulesMultipleTests.java
@@ -447,7 +447,7 @@ public class WindupRulesMultipleTests {
             }
         }
         Assert.assertTrue("No test file matching rule",foundMatchingTestFile);
-        Assert.assertTrue("Test rule Ids " + buildListOfFailingTestIds(failingIds) + " not found", failingIds.size() > 0);
+        Assert.assertTrue("Test rule Ids " + buildListOfFailingTestIds(failingIds) + " not found", failingIds.size() == 0);
     }
 
     private List<String> getRuleIds(Path ruleFilePath)

--- a/src/test/java/org/jboss/windup/rules/tests/WindupRulesMultipleTests.java
+++ b/src/test/java/org/jboss/windup/rules/tests/WindupRulesMultipleTests.java
@@ -295,7 +295,6 @@ public class WindupRulesMultipleTests {
 
                     Iterable<RuleExecutionModel> execInfoList = this.ruleExecutionService.findAllByProperty(RuleExecutionModel.RULE_ID,id);
 
-
                     for (RuleExecutionModel anExecInfoList : execInfoList) {
                         masterExecList.add(anExecInfoList);
                     }
@@ -448,7 +447,7 @@ public class WindupRulesMultipleTests {
             }
         }
         Assert.assertTrue("No test file matching rule",foundMatchingTestFile);
-        Assert.assertEquals("Test rule Ids " + buildListOfFailingTestIds(failingIds) + " not found", 0, failingIds.size());
+        Assert.assertTrue("Test rule Ids " + buildListOfFailingTestIds(failingIds) + " not found", failingIds.size() > 0);
     }
 
     private List<String> getRuleIds(Path ruleFilePath)
@@ -493,7 +492,7 @@ public class WindupRulesMultipleTests {
     {
         List<String> ids = new ArrayList<>();
         failingIds.forEach( id -> ids.add(id + "-test"));
-        return StringUtils.join(ids, ",");
+        return StringUtils.join(ids, ", ");
     }
 
     private File[] findMatchingTestFile(File ruleFile, File directory)


### PR DESCRIPTION
not really an enhancement, but reverting back to the original code. it got changed during my cleanup
- added a space in the comma-separated list of failing ids
- reverted an assertion back to assertTrue(msg,listsize > 0) (was accidentally: assertNotEquals(msg, 0, listzie)