### PR TITLE
WINDUPRULE-394 Changed 'user.home' property to have archive-metadata

### DIFF
--- a/rules-reviewed/rhr/springboot/tests/.rhamt/cache/nexus-indexer-data/test.archive-metadata.txt
+++ b/rules-reviewed/rhr/springboot/tests/.rhamt/cache/nexus-indexer-data/test.archive-metadata.txt
@@ -1,0 +1,1 @@
+076d3e24f8246dffc41ab9921c6d91a8e2c9b535 org.springframework.boot:spring-boot:2.0.7.RELEASE

--- a/src/test/java/org/jboss/windup/rules/tests/WindupRulesMultipleTests.java
+++ b/src/test/java/org/jboss/windup/rules/tests/WindupRulesMultipleTests.java
@@ -282,6 +282,10 @@ public class WindupRulesMultipleTests {
                 {
                     Assert.fail("Test file path from <testDataPath> tag has not been not found. Expected path to test file is: " + testDataPath.toString());
                 }
+                // in order to be able to provide data into "cache" folder, e.g. the "nexus-indexer-data" data folder,
+                // the "user.home" will be set to be the test file parent directory
+                // e.g. /windup-rulesets/rules-reviewed/rhr/springboot/tests/.rhamt/cache/nexus-indexer-data
+                System.setProperty("user.home", ruleTestFile.getParentFile().getAbsolutePath());
                 Path reportPath = outputPath.resolve("reports");
                 runWindup(context, directory, rulePaths, testDataPath, reportPath.toFile(), ruleTest.isSourceMode(), ruleTest.getSource(), ruleTest.getTarget());
 

--- a/src/test/java/org/jboss/windup/rules/tests/WindupRulesTest.java
+++ b/src/test/java/org/jboss/windup/rules/tests/WindupRulesTest.java
@@ -221,6 +221,10 @@ public class WindupRulesTest
 
                     // run windup
                     File testDataPath = new File(ruleTestFile.getParentFile(), ruleTest.getTestDataPath());
+                    // in order to be able to provide data into "cache" folder, e.g. the "nexus-indexer-data" data folder,
+                    // the "user.home" will be set to be the test file parent directory
+                    // e.g. /windup-rulesets/rules-reviewed/rhr/springboot/tests/.rhamt/cache/nexus-indexer-data
+                    System.setProperty("user.home", ruleTestFile.getParentFile().getAbsolutePath());
                     Path reportPath = outputPath.resolve("reports");
                     runWindup(context, directory, rulePaths, testDataPath, reportPath.toFile(), ruleTest.isSourceMode(), ruleTest.getSource(), ruleTest.getTarget());
 


### PR DESCRIPTION
As reported in the comment in the code:
in order to be able to provide data into `cache` folder, e.g. the `nexus-indexer-data` data folder, the `user.home` will be set to be the test file parent directory, e.g. `/windup-rulesets/rules-reviewed/rhr/springboot/tests/.rhamt/cache/nexus-indexer-data`.

I added also the test `demo-0.0.1-SNAPSHOT-2.0.7.jar` file that has 10 `2.0.7` Spring Boot JARs: i've added just one to the `test.archive-metadata.txt` but please add the other 9 as well.
The `test.archive-metadata.txt` file has a pair `hash GAV` for each line following the example i provided.
To get the hashes of the JARs, please, run an analysis and take them from the "Dependencies" report.
To get the GAV, i think it shouldn't be to difficult to derive them from JARs' names.

Once the `test.archive-metadata.txt` file will be updated, please add the `<iterable-filter size="10">` check in [`springboot-00002-test`](https://github.com/windup/windup-rulesets/pull/378/files#diff-88049a90a16e2d7d041da8952e7e7ee1R24) test 