### PR TITLE
WINDUPRULE-955 added -rhr suffix and made second rule category mandatory

### DIFF
--- a/rules/rules-reviewed/rhr/springboot/springboot-rhr.windup.xml
+++ b/rules/rules-reviewed/rhr/springboot/springboot-rhr.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset id="springboot" xmlns="http://windup.jboss.org/schema/jboss-ruleset"
+<ruleset id="springboot-rhr" xmlns="http://windup.jboss.org/schema/jboss-ruleset"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
     <metadata>
@@ -16,7 +16,7 @@
         <targetTechnology id="rhr"/>
     </metadata>
     <rules>
-        <rule id="springboot-00001">
+        <rule id="springboot-rhr-00001">
             <!-- rule condition, when it could be fired -->
             <when>
                 <dependency groupId="org.springframework.boot" artifactId="{*}" toVersion="2.2.5.RELEASE" />
@@ -29,7 +29,7 @@
                 </hint>
             </perform>
         </rule>
-        <rule id="springboot-00002">
+        <rule id="springboot-rhr-00002">
             <!-- rule condition, when it could be fired -->
             <when>
                 <or>
@@ -47,7 +47,7 @@
             </when>
             <!-- rule operation, what to do if it is fired -->
             <perform>
-                <hint title="Unsupported version of Spring Boot" effort="1" category-id="potential">
+                <hint title="Unsupported version of Spring Boot" effort="1" category-id="mandatory">
                     <message>Spring Boot has to be updated to a version supported by Red Hat Runtimes</message>
                     <link href="https://access.redhat.com/articles/3348731" title="RHOAR Component Details Overview" />
                 </hint>

--- a/rules/rules-reviewed/rhr/springboot/tests/springboot-rhr.windup.test.xml
+++ b/rules/rules-reviewed/rhr/springboot/tests/springboot-rhr.windup.test.xml
@@ -3,10 +3,10 @@
           xmlns="http://windup.jboss.org/schema/jboss-ruleset"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
     <testDataPath>data</testDataPath>
-    <rulePath>../springboot.rhamt.xml</rulePath>
+    <rulePath>../springboot-rhr.windup.xml</rulePath>
     <ruleset>
         <rules>
-            <rule id="springboot-00001-test">
+            <rule id="springboot-rhr-00001-test">
                 <when>
                     <not>
                         <iterable-filter size="18">
@@ -18,7 +18,7 @@
                     <fail message="[springboot-00001] Spring Boot update to v2.0 pre-migration hint was not found!" />
                 </perform>
             </rule>
-            <rule id="springboot-00002-test">
+            <rule id="springboot-rhr-00002-test">
                 <when>
                     <not>
                         <iterable-filter size="4">


### PR DESCRIPTION
Hi Mark,
This RHR ruleset is a complete ballsache to test as all of the springboot prefixed rules fire.
So I have renamed the ruleset from springboot.rhamt.xml to springboot-rhr.windup.xml, and reflected the changes in the rules and tests.
I have also changed the second rule from potential to mandatory.
If you are happy then please merge my PR into yours then I will merge yours to master.
Thanks,
Phil

